### PR TITLE
meta inf for galaxy compat

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   author: Thomas Maurice
-  description: Ansible Roie - Gitea
+  description: Ansible Role - Gitea
   platforms:
   - name: Debian
     versions:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,8 @@
+---
+galaxy_info:
+  author: Thomas Maurice
+  description: Ansible Roie - Gitea
+  platforms:
+  - name: Debian
+    versions:
+    - jessie


### PR DESCRIPTION
Even if just pulling from github, ansible-galaxy install needs this weird meta file.