### PR TITLE
fix gitea_db_passord typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The following have been tested with Debian 8, it should work on Ubuntu as well.
 * `gitea_db_host`: Database host string `host:port`
 * `gitea_db_name`: Database name
 * `gitea_db_user`: Database username
-* `gitea_db_passord`: Database password
+* `gitea_db_password`: Database password
 * `gitea_db_ssl`: Use SSL ? (postgres only!). Can be `required`, `disable`, `verify-full`
 * `gitea_db_path`: DB path, if you use `sqlite3`. The default is good enough to work though.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,7 +18,7 @@ gitea_db_type: sqlite3
 gitea_db_host: 127.0.0.0:3306
 gitea_db_name: root
 gitea_db_user: gitea
-gitea_db_passord: lel
+gitea_db_password: lel
 gitea_db_ssl: disable
 gitea_db_path: "{{ gitea_home }}/data/gitea.db"
 

--- a/templates/gitea.ini.j2
+++ b/templates/gitea.ini.j2
@@ -152,7 +152,7 @@ DB_TYPE  = {{ gitea_db_type }}
 HOST     = {{ gitea_db_host }}
 NAME     = {{ gitea_db_name }}
 USER     = {{ gitea_db_user }}
-PASSWD   = {{ gitea_db_passord }}
+PASSWD   = {{ gitea_db_password }}
 ; For "postgres" only, either "disable", "require" or "verify-full"
 SSL_MODE = {{ gitea_db_ssl }}
 ; For "sqlite3" and "tidb", use absolute path when you start as service


### PR DESCRIPTION
Change `gitea_db_passord` to `gitea_db_password`