### PR TITLE
bump default version to 1.7.3

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
-gitea_version: "1.0.1"
+gitea_version: "1.7.3"
 
 gitea_app_name: "Gitea"
 gitea_user: "gitea"


### PR DESCRIPTION
As this role works fine with recent versions of Gitea, we could bump the default version to a newer version.