### PR TITLE
update current stable version of gitea

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-gitea_version: "1.7.3"
+gitea_version: "1.7.4"
 
 gitea_app_name: "Gitea"
 gitea_user: "gitea"


### PR DESCRIPTION
Based on https://github.com/go-gitea/gitea/releases the current stable version of gitea is ``1.7.4``.

Thank you realy much @thomas-maurice and @madddi for updating this role.