### PR TITLE
Add toggle to do a version check before download

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Gitea is a Golang Git repository webapp, having the same look and feel as GitHub
 
 It is still under developpement, see "Disclaimer" if you can't make it work.
 
-## Sample exemple of use in a playbook
+## Sample example of use in a playbook
 
 The following have been tested with Debian 8, it should work on Ubuntu as well.
 
@@ -55,6 +55,7 @@ The following have been tested with Debian 8, it should work on Ubuntu as well.
 ## More detailed options
 ### General
 
+* `gitea_version_check`: Check if installed version != `gitea_version` before initiating binary download
 * `gitea_user`: UNIX user used by Gitea
 * `gitea_home`: Base directory to work
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 gitea_version: "1.7.5"
-gitea_version_check: false
+gitea_version_check: true
 
 gitea_app_name: "Gitea"
 gitea_user: "gitea"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 gitea_version: "1.7.5"
+gitea_version_check: false
 
 gitea_app_name: "Gitea"
 gitea_user: "gitea"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,11 @@
 ---
+- name: "Check gitea version"
+  shell: "/usr/local/bin/gitea -v | cut -d' ' -f 3"
+  register: gitea_active_version
+  changed_when: false
+  failed_when: false
+  when: gitea_version_check
+
 - name: "Download the binary"
   get_url:
     url: "{{ gitea_dl_url }}/v{{ gitea_version }}/gitea-{{ gitea_version }}-linux-{{ gitea_arch }}"
@@ -8,6 +15,7 @@
     mode: 0755
     force: true
   notify: "Restart gitea"
+  when: (gitea_version_check == false) or (gitea_active_version.stdout != gitea_version)
 
 - include: create_user.yml
 


### PR DESCRIPTION
Adds `gitea_version_check` boolean. When enabled, the playbook grabs the output of `gitea -v` and checks is against `gitea_version`. If they match, the `Download binary` task is skipped. This allows a site maintainer to add the role to their site playbook without each run kicking off a 40mb download.

If the task to get the version fails, Gitea is presumed to be not installed/deployed, and the download continues as normal.

Due to the major change in logic, `gitea_version_check` defaults to false, so anyone who doesn't explicitly opt in to doing the version check should be unimpacted by the change.

PS: Also corrected a minor spelling error in README.