### PR TITLE
Fixing deprecation warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
   register: gitea_active_version
   changed_when: false
   failed_when: false
-  when: gitea_version_check
+  when: gitea_version_check|bool
 
 - name: "Download the binary"
   get_url:
@@ -15,7 +15,7 @@
     mode: 0755
     force: true
   notify: "Restart gitea"
-  when: (not gitea_version_check) or (gitea_active_version.stdout != gitea_version)
+  when: (not gitea_version_check|bool) or (gitea_active_version.stdout != gitea_version)
 
 - include: create_user.yml
 
@@ -51,4 +51,4 @@
   when: ansible_service_mgr == "systemd"
 
 - include: fail2ban.yml
-  when: gitea_fail2ban_enabled
+  when: gitea_fail2ban_enabled|bool


### PR DESCRIPTION
ANsible comes with the error:
```bash
[DEPRECATION WARNING]: evaluating gitea_fail2ban_enabled as a bare variable, this
behaviour will go away and you might need to add |bool to the expression in the future. 
Also see CONDITIONAL_BARE_VARS configuration toggle.. This feature will be
removed in version 2.12. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.
```

appending ``|bool`` after a boolean variable will resolve the issue.