### PR TITLE
Feature/smtp creds

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ The following have been tested with Debian 8, it should work on Ubuntu as well.
 * `gitea_mailer_skip_verify`: Skip SMTP TLS certificate verification (true/false)
 * `gitea_mailer_tls_enabled`: Enable TLS for SMTP connection (true/false)
 * `gitea_mailer_host`: SMTP server hostname and port
+* `gitea_mailer_user`: SMTP server username
+* `gitea_mailer_password`: SMTP server password
 * `gitea_mailer_from`: Sender mail address
 
 ### Fail2Ban configuration

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,6 +47,8 @@ gitea_mailer_skip_verify: false
 gitea_mailer_tls_enabled: true
 gitea_mailer_host: localhost:25
 gitea_mailer_from: noreply@your.domain
+gitea_mailer_user: ""
+gitea_mailer_password: ""
 
 gitea_fail2ban_enabled: false
 gitea_fail2ban_jail_maxretry: 10

--- a/templates/gitea.ini.j2
+++ b/templates/gitea.ini.j2
@@ -126,9 +126,9 @@ IS_TLS_ENABLED = {{ gitea_mailer_tls_enabled }}
 ; Mail from address, RFC 5322. This can be just an email address, or the `"Name" <email@example.com>` format
 FROM                    = {{ gitea_mailer_from }}
 ; Mailer user name and password
-USER =
+USER                    = {{ gitea_mailer_user }}
 ; Use PASSWD = `your password` for quoting if you use special characters in the password.
-PASSWD =
+PASSWD                  = `{{ gitea_mailer_password }}`
 ; Send mails as plain text
 SEND_AS_PLAIN_TEXT = false
 ; Set Mailer Type (either SMTP, sendmail or dummy to just send to the log)


### PR DESCRIPTION
This adds config vars to add SMTP login credentials: user/password.

For SMTP-servers (all of them?) that require login.