### PR TITLE
Update Version to v1.8.3

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-gitea_version: "1.8.2"
+gitea_version: "1.8.3"
 gitea_version_check: true
 
 gitea_app_name: "Gitea"


### PR DESCRIPTION
A New Version of gitea is available:
https://github.com/go-gitea/gitea/releases/tag/v1.8.3