### PR TITLE
Enable git lfs options

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,9 @@ gitea_http_port: 3000
 gitea_disable_http_git: false
 gitea_offline_mode: true
 
+gitea_lfs_server_enabled: false
+gitea_lfs_content_path: "data/lfs"
+
 gitea_db_type: sqlite3
 gitea_db_host: 127.0.0.0:3306
 gitea_db_name: root

--- a/templates/gitea.ini.j2
+++ b/templates/gitea.ini.j2
@@ -51,6 +51,12 @@ SSH_LISTEN_PORT       = %(SSH_PORT)s
 OFFLINE_MODE          = {{ gitea_offline_mode }}
 ; Default path for App data
 APP_DATA_PATH         = {{ gitea_home }}/data
+{%- if gitea_lfs_server_enabled | bool %}
+;Enables git-lfs support.
+LFS_START_SERVER      = true
+; Where to store LFS files.
+LFS_CONTENT_PATH      = {{ gitea_lfs_content_path }}
+{%- endif %}
 
 [database]
 ; Either "mysql", "postgres", "mssql" or "sqlite3", it's your choice


### PR DESCRIPTION
With this change it is possible to enable the git-lfs server.
And to configure where data are stored.

Info about LFS: [git-lfs.github.com](https://git-lfs.github.com/)