### PR TITLE
Add back oauth2 parameters

### DIFF
--- a/templates/gitea.ini.j2
+++ b/templates/gitea.ini.j2
@@ -177,3 +177,7 @@ BUFFER_LEN = 10000
 LEVEL      = Info
 REDIRECT_MACARON_LOG = false
 
+[oauth2]
+ENABLE = {{ gitea_oauth2_enabled }}
+JWT_SECRET = {{ gitea_oauth2_jwt_secret }}
+


### PR DESCRIPTION
There's documentation and defaults for oauth2, but it's not present in the config template.