### PR TITLE
check that jwt token is < 32 chars to prevent gitea from crashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ As this will only deploy config files, fail2ban already has to be installed or o
 ### Oauth2 provider configuration
 
 * `gitea_oauth2_enabled`: Enable the Oauth2 provider (true/false)
-* `gitea_oauth2_jwt_secret`: JWT secret
+* `gitea_oauth2_jwt_secret`: JWT secret, cannot be longer than 32 characters
+
 
 ### Metrics endpoint configuration
 

--- a/tasks/check-variables.yml
+++ b/tasks/check-variables.yml
@@ -1,0 +1,7 @@
+---
+- name: run checks to ensure set variables do not crash gitea
+  block:
+    - fail:
+        msg: 'gitea_oauth2_jwt_secret cannot be longer than 32 characters. Please reduce the length of your token'
+      when: gitea_oauth2_jwt_secret | length > 32
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+
+- include: check-variables.yml
+
 - name: "Check gitea version"
   shell: "set -eo pipefail; /usr/local/bin/gitea -v | cut -d' ' -f 3"
   register: gitea_active_version


### PR DESCRIPTION
If gitea_oauth2_jwt_secret is set to a string longer than 32 characters, gitea will crash upon startup with a runtime error, thus preventing rollout of this role from completing succesfully.
A play using this role should exit early with a warning if this condition would be encountered.

This pull request adds:
- a notice in the Readme about the maximium length of the variable
- a new block of tasks to run checks on variables (currently only including a check of gitea_oauth2_jwt_secret)

