### PR TITLE
Update default version to 1.11.5

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-gitea_version: "1.11.4"
+gitea_version: "1.11.5"
 gitea_version_check: true
 
 gitea_app_name: "Gitea"


### PR DESCRIPTION
Gitea Release [v1.11.5](https://github.com/go-gitea/gitea/releases/tag/v1.11.5) is available \o/