### PR TITLE
Add config option to set repository path different than home_path

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ gitea_user: "gitea"
 gitea_home: "/var/lib/gitea"
 gitea_shell: "/bin/false"
 
+gitea_repository_root: "{{ gitea_home }}"
 gitea_user_repo_limit: -1
 
 gitea_http_domain: localhost

--- a/templates/gitea.ini.j2
+++ b/templates/gitea.ini.j2
@@ -13,7 +13,7 @@ RUN_USER = {{ gitea_user }}
 RUN_MODE = prod
 
 [repository]
-ROOT                  = {{ gitea_home }}
+ROOT                  = {{ gitea_repository_root }}
 ; Force every new repository to be private
 FORCE_PRIVATE         = {{ gitea_force_private }}
 ; Global limit of repositories per user, applied at creation time. -1 means no limit


### PR DESCRIPTION
This PR adds an additional config option to allow different repository roots than home path