### PR TITLE
Allow gitea.service binding to ports lower than 1024

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The following code has been tested with Debian 8, it should work on Ubuntu as we
 * `gitea_user`: UNIX user used by Gitea
 * `gitea_home`: Base directory to work
 * `gitea_dl_url`: The URL, the compiled gitea-binary will be downloaded from
+* `gitea_systemd_cap_net_bind_service`: Adds `AmbientCapabilities=CAP_NET_BIND_SERVICE` to systemd service file
 
 ### Look and feel
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ gitea_app_name: "Gitea"
 gitea_user: "gitea"
 gitea_home: "/var/lib/gitea"
 gitea_shell: "/bin/false"
+gitea_systemd_cap_net_bind_service: false
 
 gitea_repository_root: "{{ gitea_home }}"
 gitea_user_repo_limit: -1

--- a/templates/gitea.service.j2
+++ b/templates/gitea.service.j2
@@ -7,7 +7,9 @@ User={{ gitea_user }}
 ExecStart=/usr/local/bin/gitea web -c /etc/gitea/gitea.ini
 Restart=on-failure
 WorkingDirectory={{ gitea_home }}
+{% if gitea_systemd_cap_net_bind_service %}
 AmbientCapabilities=CAP_NET_BIND_SERVICE
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/gitea.service.j2
+++ b/templates/gitea.service.j2
@@ -7,6 +7,7 @@ User={{ gitea_user }}
 ExecStart=/usr/local/bin/gitea web -c /etc/gitea/gitea.ini
 Restart=on-failure
 WorkingDirectory={{ gitea_home }}
+AmbientCapabilities=CAP_NET_BIND_SERVICE
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This PR adds `AmbientCapabilities=CAP_NET_BIND_SERVICE` to `gitea.service.j2`. This is useful if you want to use a ssh or http port lower than 1024.