### PR TITLE
Update gitea to 1.12.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-gitea_version: "1.11.5"
+gitea_version: "1.12.0"
 gitea_version_check: true
 
 gitea_app_name: "Gitea"


### PR DESCRIPTION
New gitea release [1.12.0](https://github.com/go-gitea/gitea/releases/tag/v1.12.0-rc1) is available \o/