### PR TITLE
Update gitea to v1.11.6

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-gitea_version: "1.11.5"
+gitea_version: "1.11.6"
 gitea_version_check: true
 gitea_dl_url: "https://github.com/go-gitea/gitea/releases/download/v{{ gitea_version }}/gitea-{{ gitea_version }}-linux-{{ gitea_arch }}"
 


### PR DESCRIPTION
New Release available:
https://github.com/go-gitea/gitea/releases/tag/v1.11.6