### PR TITLE
Bugfix: set -o pipefail fails silently.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,8 @@
 
 - name: "Check gitea version"
   shell: "set -eo pipefail; /usr/local/bin/gitea -v | cut -d' ' -f 3"
+  args:
+    executable: /bin/bash
   register: gitea_active_version
   changed_when: false
   failed_when: false


### PR DESCRIPTION
This is due the fact that Ansible often takes another default shell
to execute its commands, e.g., /bin/sh.
Solution is to require /bin/bash for the particular command.

PR as discussed in issue https://github.com/thomas-maurice/ansible-role-gitea/issues/48