### PR TITLE
Add configuration option for enabling notify email

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ The following code has been tested with Debian 8, it should work on Ubuntu as we
 * `gitea_mailer_user`: SMTP server username
 * `gitea_mailer_password`: SMTP server password
 * `gitea_mailer_from`: Sender mail address
+* `gitea_enable_notify_mail`:  Whether e-mail should be send to watchers of a repository when something happens. Default: `false`
 
 ### Fail2Ban configuration
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,6 +46,7 @@ gitea_show_registration_button: true
 gitea_require_signin: true
 gitea_enable_captcha: true
 gitea_only_allow_external_registration: false
+gitea_enable_notify_mail: false
 
 gitea_force_private: false
 

--- a/templates/gitea.ini.j2
+++ b/templates/gitea.ini.j2
@@ -116,6 +116,7 @@ RECAPTCHA_SITEKEY =
 ; Show Registration button
 SHOW_REGISTRATION_BUTTON = {{ gitea_show_registration_button }}
 ALLOW_ONLY_EXTERNAL_REGISTRATION = {{ gitea_only_allow_external_registration }}
+ENABLE_NOTIFY_MAIL = {{ gitea_enable_notify_mail }}
 
 [mailer]
 ENABLED                 = {{ gitea_mailer_enabled }}


### PR DESCRIPTION
If this config option is enabled, watchers of a repository will get an email on changes.