### PR TITLE
also create inders and logs directory as gitea

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,6 +29,7 @@
     path: "{{ item }}"
     state: directory
     owner: "{{ gitea_user }}"
+    recurse: True
   with_items:
     - "/etc/gitea"
     - "{{ gitea_home }}"
@@ -36,6 +37,8 @@
     - "{{ gitea_home }}/custom"
     - "{{ gitea_home }}/custom/https"
     - "{{ gitea_home }}/custom/mailer"
+    - "{{ gitea_home }}/indexers"
+    - "{{ gitea_home }}/logs"
 
 - include: install_systemd.yml
   when: ansible_service_mgr == "systemd"


### PR DESCRIPTION
Recursively set the gitea user as owner of all it's directories (and create /indexers and /logs directories.
This is needed if one tried to start gitea as root before.

Gitea didn't start after running this role, to try to figure out what was wrong I logged in as root and ran 
`/usr/local/bin/gitea web -c /etc/gitea/gitea.ini`
This resulted in te below ownerships (Which then later also fails to start gitea as gitea user since it can't create it's og files.

```
[root@gitea ~]# ls -alh /var/lib/gitea/ 
total 40K
drwx------  6 gitea gitea 4.0K Aug 15 23:25 .
drwxr-xr-x 22 root  root  4.0K Aug 15 23:11 ..
-rw-r--r--  1 gitea gitea   18 Nov  8  2019 .bash_logout
-rw-r--r--  1 gitea gitea  141 Nov  8  2019 .bash_profile
-rw-r--r--  1 gitea gitea  312 Nov  8  2019 .bashrc
-rw-r--r--  1 gitea gitea  123 Aug 15 23:25 .gitconfig
drwxr-xr-x  4 gitea root  4.0K Aug 15 23:11 custom
drwxr-xr-x  4 gitea root  4.0K Aug 15 23:20 data
drwxr-xr-x  4 root  root  4.0K Aug 15 23:20 indexers
drwxr-xr-x  2 root  root  4.0K Aug 15 23:22 log
```