### PR TITLE
reload systemd via handler

### DIFF
--- a/tasks/install_systemd.yml
+++ b/tasks/install_systemd.yml
@@ -9,3 +9,8 @@
   notify:
     - "Reload systemd"
     - "Restart gitea"
+
+# systemd to be reloaded the first time because it is the only way Systemd is going to be aware of the new unit file.
+- name: "Reload systemd"
+  systemd:
+    daemon_reload: true

--- a/tasks/install_systemd.yml
+++ b/tasks/install_systemd.yml
@@ -9,7 +9,3 @@
   notify:
     - "Reload systemd"
     - "Restart gitea"
-
-- name: "Reload systemd"
-  systemd:
-    daemon_reload: true


### PR DESCRIPTION
Is this reload of systemd still needed here? It should be triggered via the handler? Or is this a race condition where systemd has to be reloaded at least once before proceeding?