### PR TITLE
fix repo path

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,7 +9,7 @@ gitea_home: "/var/lib/gitea"
 gitea_shell: "/bin/false"
 gitea_systemd_cap_net_bind_service: false
 
-gitea_repository_root: "{{ gitea_home }}"
+gitea_repository_root: "{{ gitea_home }}/repos"
 gitea_user_repo_limit: -1
 
 gitea_http_domain: localhost


### PR DESCRIPTION
Warning: Breaking changes ....
the repositories should not be beside mixed with the folder for `custom`, `data`, `https`, `indexers` and `logs`.
 
E.g. what happen if a user register with the name of `logs`

----
PR cherry-pick df36a413ec7836cea279856b655072138b141aa8 of #62 