### PR TITLE
bump gitea version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-gitea_version: "1.12.4"
+gitea_version: "1.13.0"
 gitea_version_check: true
 gitea_dl_url: "https://github.com/go-gitea/gitea/releases/download/v{{ gitea_version }}/gitea-{{ gitea_version }}-linux-{{ gitea_arch }}"
 


### PR DESCRIPTION
gitea 1.13.0 was released which fixes security issues

some breaking changes were reported in the release notes but I didn't find any issues with them on my system, caution is advised


    SECURITY
        Add Allow-/Block-List for Migrate & Mirrors (#13610) (#13776)
        Prevent git operations for inactive users (#13527) (#13536)
        Disallow urlencoded new lines in git protocol paths if there is a port (#13521) (#13524)
        Mitigate Security vulnerability in the git hook feature (#13058)
        Disable DSA ssh keys by default (#13056)
        Set TLS minimum version to 1.2 (#12689)
        Use argon as default password hash algorithm (#12688)
    BREAKING
        Set RUN_MODE prod by default (#13765) (#13767)
        Don't replace underscores in auto-generated IDs in goldmark (#12805)
        Add Primary Key to Topic and RepoTopic tables (#12639)
        Disable password complexity check default (#12557)
        Change PIDFile default from /var/run/gitea.pid to /run/gitea.pid (#12500)
        Add extension Support to Attachments (allow all types for releases) (#12465)
        Remove IE11 Support (#11470)