### PR TITLE
Add disable_git_hooks config option to security

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,13 @@ The following code has been tested with Debian 8, it should work on Ubuntu as we
 * `gitea_show_registration_button`: Do you want to show the registration button? (true/false)
 * `gitea_require_signin`: Do you require a signin to see repo's (even public ones) ? (true/false)
 * `gitea_enable_captcha`: Do you want to enable captcha's ? (true/false)
-* `gitea_secret_key`: Cookie secret key
-* `gitea_internal_token`: Internal API token
 * `gitea_themes`: List of enabled themes
 * `gitea_theme_default`: Default theme
+
+### Security
+* `gitea_secret_key`: Cookie secret key
+* `gitea_internal_token`: Internal API token
+* `gitea_disable_git_hooks`: Do you want to disable the interface to add git hooks? If enabled it could be a security bug as it can be used for RCE. Defaults to true (true/false)
 
 ### Limits
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,6 +38,7 @@ gitea_ssh_port: 2222
 
 gitea_secret_key: T0pS3cr31
 gitea_internal_token: SomethingVeryLong
+gitea_disable_git_hooks: true
 
 gitea_show_user_email: false
 gitea_disable_gravatar: true

--- a/templates/gitea.ini.j2
+++ b/templates/gitea.ini.j2
@@ -99,6 +99,7 @@ SECRET_KEY              = {{ gitea_secret_key }}
 INTERNAL_TOKEN          = {{ gitea_internal_token }}
 ; How long to remember that an user is logged in before requiring relogin (in days)
 LOGIN_REMEMBER_DAYS = 7
+DISABLE_GIT_HOOKS       = {{ gitea_disable_git_hooks }}
 
 [service]
 ; Disallow registration, only allow admins to create accounts.


### PR DESCRIPTION
Also move `gitea_security_key` and `gitea_internal_token` to an extra security section in readme