### PR TITLE
add linting check and fix warning

### DIFF
--- a/.github/workflows/ansible-linting-check.yml
+++ b/.github/workflows/ansible-linting-check.yml
@@ -1,0 +1,20 @@
+name: Ansible Lint check
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Lint Ansible Playbook
+      uses: ansible/ansible-lint-action@master
+      with:
+        targets: "."
+        # [required]
+        # Paths to ansible files (i.e., playbooks, tasks, handlers etc..)
+        args: ""
+        # [optional]

--- a/.github/workflows/ansible-linting-check.yml
+++ b/.github/workflows/ansible-linting-check.yml
@@ -1,3 +1,4 @@
+---
 name: Ansible Lint check
 
 on: [push, pull_request]
@@ -8,13 +9,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
 
-    - name: Lint Ansible Playbook
-      uses: ansible/ansible-lint-action@master
-      with:
-        targets: "."
-        # [required]
-        # Paths to ansible files (i.e., playbooks, tasks, handlers etc..)
-        args: ""
-        # [optional]
+      - uses: actions/checkout@v2
+
+      - name: Lint Ansible Playbook
+        uses: ansible/ansible-lint-action@master
+        with:
+          targets: "."
+          # [required]
+          # Paths to ansible files (i.e., playbooks, tasks, handlers etc..)
+          args: ""
+          # [optional]

--- a/tasks/install_systemd.yml
+++ b/tasks/install_systemd.yml
@@ -10,7 +10,8 @@
     - "Reload systemd"
     - "Restart gitea"
 
-# systemd to be reloaded the first time because it is the only way Systemd is going to be aware of the new unit file.
+# systemd to be reloaded the first time because
+#  it is the only way Systemd is going to be aware of the new unit file.
 - name: "Reload systemd"
   systemd:
     daemon_reload: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,6 +29,7 @@
     path: "{{ item }}"
     state: directory
     owner: "{{ gitea_user }}"
+    mode: '0755'
     recurse: True
   with_items:
     - "/etc/gitea"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,7 +30,7 @@
     state: directory
     owner: "{{ gitea_user }}"
     mode: '0755'
-    recurse: True
+    recurse: true
   with_items:
     - "/etc/gitea"
     - "{{ gitea_home }}"


### PR DESCRIPTION
There is this linting message:
```yml
[208] File permissions unset or incorrect
tasks/main.yml:27
Task/Handler: Create config and data directory
```

I fixed it in this commit and added a github action
to run the official™ ansible linting check!

More info about the github action is available at [the marketplace](https://github.com/marketplace/actions/ansible-lint).
@thomas-maurice 