### PR TITLE
Update file permissions for "{{ gitea_home }}"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,7 +40,7 @@
     state: directory
     owner: "{{ gitea_user }}"
     group: "{{ gitea_group }}"
-    mode: '0755'
+    mode: 'u=rwX,g=rX,o='
     recurse: true
   with_items:
     - "{{ gitea_home }}"


### PR DESCRIPTION
The file permissions for {{ gitea_home }} especially in conjunction with the recurse: true flag are on closer inspection very open to all and also have a +x set on files.

This should be done better. And I have done here now.

By the way: To improve the -x on normal files in his gitea installation this shell command was useful for me
```
find . -type f -exec chmod a-x {} \+;
find . -type f -exec chmod u=rwX {} \+;
 find repositories/ -type f -path '*/hooks/*' -exec chmod u+x {} \+
```