### PR TITLE
Add / correct accepted SSL modes for PostgreSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The following code has been tested with Debian 8, it should work on Ubuntu as we
 * `gitea_db_name`: Database name
 * `gitea_db_user`: Database username
 * `gitea_db_password`: Database password
-* `gitea_db_ssl`: Use SSL ? (postgres only!). Can be `required`, `disable`, `verify-full`
+* `gitea_db_ssl`: Use SSL ? (postgres only!). Can be `require`, `disable`, `verify-ca` or `verify-full`
 * `gitea_db_path`: DB path, if you use `sqlite3`. The default is good enough to work though.
 
 ### Mailer configuration

--- a/templates/gitea.ini.j2
+++ b/templates/gitea.ini.j2
@@ -70,7 +70,7 @@ NAME     = {{ gitea_db_name }}
 USER     = {{ gitea_db_user }}
 ; Use PASSWD = `your password` for quoting if you use special characters in the password.
 PASSWD   = {{ gitea_db_password }}
-; For Postgres, either "disable" (default), "require", or "verify-full"
+; For Postgres, either "disable" (default), "require", "verify-ca" or "verify-full"
 ; For MySQL, either "false" (default), "true", or "skip-verify"
 SSL_MODE = {{ gitea_db_ssl }}
 ; For "sqlite3" and "tidb", use an absolute path when you start gitea as service


### PR DESCRIPTION
Supported SSL modues for PostgreSQL are: disabled, require, verify-ca
and verify-full.

This fix adds `verify-ca` to README.md and gitea.ini.j2, and corrects
`require` to `required` in README.md.