### PR TITLE
update gitea to 1.13.4

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-gitea_version: "1.13.2"
+gitea_version: "1.13.4"
 gitea_version_check: true
 gitea_dl_url: "https://github.com/go-gitea/gitea/releases/download/v{{ gitea_version }}/gitea-{{ gitea_version }}-linux-{{ gitea_arch }}"
 gitea_gpg_key: "7C9E68152594688862D62AF62D9AE806EC1592E2"


### PR DESCRIPTION
The current release of gitea is [v1.13.4](https://github.com/go-gitea/gitea/releases/tag/v1.13.4).

The current master of this role is not able to do a version update properly. PLEASE first merge https://github.com/thomas-maurice/ansible-role-gitea/pull/81