### PR TITLE
Fix git ssh operations when using system sshd

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The following code has been tested with Debian 8, it should work on Ubuntu as we
 
 * `gitea_ssh_listen`: Bind address for the SSH server
 * `gitea_ssh_domain`: SSH domain (displayed in your clone URLs)
-* `gitea_start_ssh`: Do you want to start a built-in SSH server ? (true/false)
+* `gitea_start_ssh`: Do you want to start a built-in SSH server ? (true/false) If set to false the system ssh server will be used.
 * `gitea_ssh_port`: SSH bind port
 
 ### Database configuration

--- a/tasks/create_user.yml
+++ b/tasks/create_user.yml
@@ -4,10 +4,12 @@
     name: "{{ gitea_group }}"
     system: true
     state: "present"
-
-- name: "If the system sshd ist used, we must not use /bin/false use the normal /bin/sh. "
+    
+# If the system sshd ist used, we must not use /bin/false. Instead use the normal /bin/sh to enable gitea to run its commands
+- name: Switch shell when not using the builtin ssh server
   set_fact:
     gitea_shell: "/bin/sh"
+  when: "not gitea_start_ssh"
 
 - name: "Create Gitea user"
   user:

--- a/tasks/create_user.yml
+++ b/tasks/create_user.yml
@@ -4,12 +4,12 @@
     name: "{{ gitea_group }}"
     system: true
     state: "present"
-    
+
 # If the system sshd ist used, we must not use /bin/false. Instead use the normal /bin/sh to enable gitea to run its commands
 - name: Switch shell when not using the builtin ssh server
   set_fact:
     gitea_shell: "/bin/sh"
-  when: "not gitea_start_ssh"
+  when: "not gitea_start_ssh and gitea_shell == '/bin/false'"
 
 - name: "Create Gitea user"
   user:

--- a/tasks/create_user.yml
+++ b/tasks/create_user.yml
@@ -5,6 +5,10 @@
     system: true
     state: "present"
 
+- name: "If the system sshd ist used, we must not use /bin/false use the normal /bin/sh. "
+  set_fact:
+    gitea_shell: "/bin/sh"
+
 - name: "Create Gitea user"
   user:
     name: "{{ gitea_user }}"


### PR DESCRIPTION
If you use the system sshd the /bin/false shell will result in mysterios erros when trying to clone a repository, because /bin/false can not provide a login shell to enable ssh to execute commands.

Please refere tohttps://man.openbsd.org/sshd - Section Login Process

"9. Runs user's shell or command. All commands are run under the user's login shell as specified in the system password database."