### PR TITLE
fail2ban only if installed

### DIFF
--- a/tasks/fail2ban.yml
+++ b/tasks/fail2ban.yml
@@ -7,6 +7,7 @@
     group: root
     mode: 0444
   notify: Restart fail2ban
+  when: "'fail2ban' in ansible_facts.packages"  
 
 - name: Install fail2ban jail
   template:
@@ -16,3 +17,4 @@
     group: root
     mode: 0444
   notify: Restart fail2ban
+  when: "'fail2ban' in ansible_facts.packages"  

--- a/tasks/fail2ban.yml
+++ b/tasks/fail2ban.yml
@@ -7,7 +7,7 @@
     group: root
     mode: 0444
   notify: Restart fail2ban
-  when: "'fail2ban' in ansible_facts.packages"  
+  when: "'fail2ban' in ansible_facts.packages"
 
 - name: Install fail2ban jail
   template:
@@ -17,4 +17,10 @@
     group: root
     mode: 0444
   notify: Restart fail2ban
-  when: "'fail2ban' in ansible_facts.packages"  
+  when: "'fail2ban' in ansible_facts.packages"
+
+- name: warn if fail2ban is not installed
+  ansible.builtin.fail:
+    msg: "the package fail2ban is not installed. no fail2ban filters deployed."
+  when: "'fail2ban' not in ansible_facts.packages"
+  ignore_errors: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,10 @@
     - "{{ ansible_distribution | lower }}.yml"
     - "{{ ansible_os_family | lower }}.yml"
 
+- name: Gather installed packages for checks in the role (fail2ban)
+  ansible.builtin.package_facts:
+    manager: auto
+
 - name: "Check gitea version"
   shell: "set -eo pipefail; /usr/local/bin/gitea -v | cut -d' ' -f 3"
   args:


### PR DESCRIPTION
If fail2ban is not installed on remote the role will fail.

I have added a check to only run fail2ban if it is installed on the remote machine (not tested yet).

~~Possible problem: There is no message to the users at the moment and they won't know that fail2ban hasn't been configured (because not installed).~~ Fixed with help of @DO1JLR 