### PR TITLE
Update fail2ban filter to comply with gitea version 1.14.0

### DIFF
--- a/templates/fail2ban/filter.conf.j2
+++ b/templates/fail2ban/filter.conf.j2
@@ -1,4 +1,4 @@
 # Managed by Ansible
 [Definition]
-failregex =  .*Failed authentication attempt for .* from <HOST>
+failregex = .*(Failed authentication attempt|invalid credentials|Attempted access of unknown user).* from <HOST>
 ignoreregex =


### PR DESCRIPTION
This should fix the breaking change in 1.14.0 affecting fail2ban. 

[Blog entry 1.14.0](https://blog.gitea.io/2021/04/gitea-1.14.0-is-released/)