### PR TITLE
Update main.yml

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-gitea_version: "1.13.7"
+gitea_version: "1.15.10"
 gitea_version_check: true
 gitea_dl_url: "https://github.com/go-gitea/gitea/releases/download/v{{ gitea_version }}/gitea-{{ gitea_version }}-linux-{{ gitea_arch }}"
 gitea_gpg_key: "7C9E68152594688862D62AF62D9AE806EC1592E2"


### PR DESCRIPTION
gitea security fixes

     

SECURITY

    Bump mermaid from 8.10.1 to 8.13.8 (#18198) (#18206)